### PR TITLE
Bump Slint to version 1.3.2

### DIFF
--- a/slint-base/args.json
+++ b/slint-base/args.json
@@ -1,7 +1,7 @@
 {
     "image_prefix": "/slint-base",
     "registry": "commontorizon",
-    "version": "3.0.9-bookworm-1.3.0",
+    "version": "3.0.9-bookworm-1.3.2",
     "multiarch": false,
     "machines": [
         {
@@ -9,7 +9,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.3.0",
+            "BASE_VERSION": "3.0.9-bookworm-1.3.2",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm",
             "GPU": ""
@@ -19,7 +19,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.3.0",
+            "BASE_VERSION": "3.0.9-bookworm-1.3.2",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm64",
             "GPU": ""
@@ -29,7 +29,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.3.0",
+            "BASE_VERSION": "3.0.9-bookworm-1.3.2",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm64",
             "GPU": "-vivante"

--- a/slint-sdk/Containerfile
+++ b/slint-sdk/Containerfile
@@ -88,10 +88,10 @@ ENV CMAKE_GENERATOR=Ninja
 
 # Build Slint
 ##
-# ⚠️ BUILDING SLINT v1.3.0
+# ⚠️ BUILDING SLINT v1.3.2
 # ⚠️ Check available versions here: https://github.com/slint-ui/slint/releases
 ##
-RUN git clone https://github.com/slint-ui/slint --depth 1 --branch v1.3.0 /slint
+RUN git clone https://github.com/slint-ui/slint --depth 1 --branch v1.3.2 /slint
 RUN RUST_TOOLCHAIN_ARCH=$(cat /rust-toolchain-arch.txt) && \
     cd /slint \
     && mkdir build \

--- a/slint-sdk/args.json
+++ b/slint-sdk/args.json
@@ -1,7 +1,7 @@
 {
     "image_prefix": "/slint-sdk",
     "registry": "commontorizon",
-    "version": "3.0.9-bookworm-1.3.0",
+    "version": "3.0.9-bookworm-1.3.2",
     "multiarch": false,
     "machines": [
         {


### PR DESCRIPTION
This patch release fixes bugs and regressions.