### PR TITLE
torizon: add a literal Torizon container image

### DIFF
--- a/.github/workflows/build-torizon-container.yml
+++ b/.github/workflows/build-torizon-container.yml
@@ -1,0 +1,36 @@
+name: Build and Push Torizon Container Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  TORIZON_VERSION: "6.5.0"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Build and push Docker image
+      run: |
+        docker buildx create --use
+        docker buildx inspect --bootstrap
+        docker buildx build \
+          --platform linux/amd64 \
+          --build-arg TORIZON_VERSION=${{ env.TORIZON_VERSION }} \
+          -t ghcr.io/${{ github.repository_owner }}/torizon:latest \
+          -t ghcr.io/${{ github.repository_owner }}/torizon:${{ env.TORIZON_VERSION }} \
+          -f torizon/Containerfile \
+          --push \
+          .

--- a/torizon/Containerfile
+++ b/torizon/Containerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:latest as download-wic
+ARG TORIZON_VERSION
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y curl unzip \
+    && curl -L -o torizon.zip https://github.com/commontorizon/meta-common-torizon/releases/download/v${TORIZON_VERSION}-common/torizon-core-common-docker-dev-v${TORIZON_VERSION}-common-qemux86-64.zip \
+    && unzip torizon.zip -d /torizon \
+    && rm torizon.zip \
+    && mv /torizon/*.wic /torizon/torizon.wic
+
+FROM ubuntu:latest as qemu
+COPY --from=download-wic /torizon/torizon.wic .
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        qemu-system && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 2222
+CMD ["qemu-system-x86_64", "-cpu", "host", "-nic", "user,hostfwd=tcp::2222-:22", "-machine", "pc", "-vga", "virtio", "-m", "4096", "-drive", "file=/torizon.wic,format=raw", "-bios", "/usr/share/ovmf/OVMF.fd", "-enable-kvm"]

--- a/torizon/docker-compose.yml
+++ b/torizon/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  torizon:
+    image: ghcr.io/commontorizon/Containerfiles/torizon:latest
+    devices:
+      - /dev/kvm
+    environment:
+      - DISPLAY=${DISPLAY:-:1}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    ports:
+      - "2222:2222"
+networks:
+  qemu:
+    driver: bridge


### PR DESCRIPTION
... which builds a container with the latest qemux86_64 common Torizon image and installs qemu-system to enable Torizon to run as an actual virtual machine.

Defaults to using kvm.