### PR TITLE
Prospective fix for expiring cmake archive key breaking builds

### DIFF
--- a/slint-base/args.json
+++ b/slint-base/args.json
@@ -1,7 +1,7 @@
 {
     "image_prefix": "/slint-base",
     "registry": "commontorizon",
-    "version": "3.0.9-bookworm-1.3.2",
+    "version": "3.0.9-bookworm-1.3.2-1",
     "multiarch": false,
     "machines": [
         {

--- a/slint-sdk/Containerfile
+++ b/slint-sdk/Containerfile
@@ -34,6 +34,7 @@ RUN apt-get update && \
     echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
     apt-get update && \
     apt-get install --assume-yes cmake ninja-build make && \
+    rm -f /etc/apt/sources.list.d/kitware.list /usr/share/keyrings/kitware-archive-keyring.gpg && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=755 armhf-toolchain.cmake arm64-toolchain.cmake /


### PR DESCRIPTION
Remove the repo and key again after installing cmake, to avoid problems like in

https://community.toradex.com/t/cant-build-c-slint-application/21552/2