### PR TITLE
Slint: Add support for the LinuxKMS backend in the SDK and target images

### DIFF
--- a/slint-base/Containerfile
+++ b/slint-base/Containerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \
     libfontconfig1 \
     libxkbcommon0 \
+    libinput10 \
     fonts-noto-core \
     fonts-noto-cjk \
     fonts-noto-cjk-extra \

--- a/slint-base/args.json
+++ b/slint-base/args.json
@@ -1,7 +1,7 @@
 {
     "image_prefix": "/slint-base",
     "registry": "commontorizon",
-    "version": "3.0.9-bookworm-1.5.1",
+    "version": "3.3.0-bookworm-1.5.1",
     "multiarch": false,
     "machines": [
         {
@@ -9,7 +9,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.5.1",
+            "BASE_VERSION": "3.3.0-bookworm-1.5.1",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm",
             "GPU": ""
@@ -19,7 +19,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.5.1",
+            "BASE_VERSION": "3.3.0-bookworm-1.5.1",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm64",
             "GPU": ""
@@ -29,7 +29,7 @@
             "BASE_REGISTRY": "torizon",
             "BASE_IMAGE": "/slint-sdk",
             "BASE_IMAGE2": "/wayland-base",
-            "BASE_VERSION": "3.0.9-bookworm-1.5.1",
+            "BASE_VERSION": "3.3.0-bookworm-1.5.1",
             "BASE_VERSION2": "3.0.8",
             "IMAGE_ARCH": "arm64",
             "GPU": "-vivante"

--- a/slint-sdk/Containerfile
+++ b/slint-sdk/Containerfile
@@ -90,10 +90,11 @@ RUN \
 # Don't require font-config when the compiler runs
 ENV RUST_FONTCONFIG_DLOPEN=on
 
+ENV PKG_CONFIG_ALLOW_CROSS=1
+
 # Default to Ninja
 ENV CMAKE_GENERATOR=Ninja
 # ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
-# ENV PKG_CONFIG_ALLOW_CROSS=1
 # ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu=-I/usr/include
 
 # Build Slint
@@ -109,8 +110,9 @@ RUN RUST_TOOLCHAIN_ARCH=$(cat /rust-toolchain-arch.txt) && \
     && cmake -DRust_CARGO_TARGET=$RUST_TOOLCHAIN_ARCH .. \
        -DCMAKE_INSTALL_PREFIX=/usr \
        -DCMAKE_BUILD_TYPE=Release \
-       -DSLINT_FEATURE_RENDERER_WINIT_SKIA=ON -DSLINT_FEATURE_RENDERER_WINIT_FEMTOVG=OFF \
+       -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_RENDERER_FEMTOVG=OFF \
        -DSLINT_FEATURE_BACKEND_WINIT=OFF -DSLINT_FEATURE_BACKEND_WINIT_WAYLAND=ON \
+       -DSLINT_FEATURE_BACKEND_LINUXKMS_NOSEAT=ON \
     && cmake --build . \
     && cmake --install . \
     && cd / \


### PR DESCRIPTION
- Enable use of pkg-config for the cross-packages (needed for libudev and libinput)
- Add libinput to the target image (required)
- Fix slint feature selection (avoid use of deprecated names, enable linuxkms backend)