### PR TITLE
create a cog-media container with alsa sound packages

### DIFF
--- a/cog-media/Containerfile
+++ b/cog-media/Containerfile
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Matheus Castello
+# SPDX-License-Identifier: MIT
+
+##
+# Board architecture
+##
+ARG IMAGE_ARCH=
+
+##
+# The registry and the namespace
+##
+ARG BASE_REGISTRY=
+
+##
+# Base container image name
+##
+ARG BASE_IMAGE=
+
+##
+# Base container version
+##
+ARG BASE_VERSION=
+
+##
+# GPU prefix
+##
+ARG GPU=
+
+FROM ${BASE_REGISTRY}${BASE_IMAGE}${GPU}:${BASE_VERSION} AS Deploy
+
+RUN apt-get -y update && \
+    apt-get install -y --no-install-recommends \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav \
+    gstreamer1.0-alsa \
+    cog && \
+    apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
+COPY start-cog.sh /usr/bin/start-browser
+COPY wait4.sh /usr/bin/wait4
+
+RUN chmod +x /usr/bin/start-browser && \
+    chmod +x /usr/bin/wait4
+
+USER torizon
+
+ENV DISPLAY=:0
+ENV COG_PLATFORM_WL_VIEW_FULLSCREEN=1
+
+ENTRYPOINT ["/usr/bin/start-browser"]
+CMD ["http://www.torizon.io"]

--- a/cog-media/args.json
+++ b/cog-media/args.json
@@ -1,0 +1,40 @@
+{
+    "image": "/cog-media",
+    "registry": "commontorizon",
+    "version": "3.3.1",
+    "multiarch": true,
+    "machines": [
+        {
+            "name": "upstream",
+            "arch": [
+                "arm",
+                "arm64",
+                "amd64"
+            ],
+            "BASE_REGISTRY": "commontorizon",
+            "BASE_IMAGE": "/wayland-base",
+            "BASE_VERSION": "3.3.1",
+            "GPU": ""
+        },
+        {
+            "name": "imx8",
+            "arch": [
+                "arm64"
+            ],
+            "BASE_REGISTRY": "commontorizon",
+            "BASE_IMAGE": "/wayland-base",
+            "BASE_VERSION": "3.3.1",
+            "GPU": "-imx8"
+        },
+        {
+            "name": "am62",
+            "arch": [
+                "arm64"
+            ],
+            "BASE_REGISTRY": "commontorizon",
+            "BASE_IMAGE": "/wayland-base",
+            "BASE_VERSION": "3.3.1",
+            "GPU": "-am62"
+        }
+    ]
+}

--- a/cog-media/docker-compose.yml
+++ b/cog-media/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  cog:
+    build:
+      context: ./cog
+      dockerfile: Containerfile
+      args:
+        NAME: ${NAME}
+        IMAGE_REGISTRY: ${IMAGE_REGISTRY}
+        IMAGE_NAME: ${IMAGE_NAME}
+        IMAGE_VERSION: ${IMAGE_VERSION}
+        BASE_REGISTRY: ${BASE_REGISTRY}
+        BASE_IMAGE: ${BASE_IMAGE}
+        BASE_VERSION: ${BASE_VERSION}
+        GPU: ${GPU}
+    image: ${IMAGE_REGISTRY}${IMAGE_NAME}${GPU}:${IMAGE_VERSION}

--- a/cog-media/start-cog.sh
+++ b/cog-media/start-cog.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# default URL
+URL="www.torizon.io"
+
+if [ ! -z "$1" ]; then
+    URL=$1
+fi
+
+OPTION=$2
+COG_COMMAND="cog $URL"
+WAIT4_COMMAND="/usr/bin/wait4 $URL '$COG_COMMAND'"
+
+if [ ! -z "$2" ] && [ "$2" = "-w" ]; then
+    # use the wait4 to wait the webserver to be up
+    eval exec $WAIT4_COMMAND
+else
+    eval exec $COG_COMMAND
+fi

--- a/cog-media/wait4.sh
+++ b/cog-media/wait4.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+URL="$1"
+TIMEOUT=300
+CMD="$2"
+
+
+echo "start"
+XSTATUS=502
+while [ $XSTATUS -eq 502 ] || [ $XSTATUS -eq 404 ] || [ $XSTATUS -eq 000 ]; do
+    sleep 1
+    XSTATUS=`curl -s --connect-timeout $TIMEOUT -o /dev/null -w "%{http_code}" $URL`
+    echo "current HTTP STATUS is $XSTATUS"
+done
+
+echo "service is up and running "
+echo "now executing $CMD "
+
+eval exec $CMD


### PR DESCRIPTION
First attempt to create a `cog-media` container that includes packages to handle sound.
This is based over `commontorizon/cog` container that has already installed the following gstreamer packs
```bash
dpkg -l | grep gstreamer

ii  libgstreamer-gl1.0-0:arm64           1.22.0-3+toradex1              arm64        GStreamer GL libraries
ii  libgstreamer-plugins-base1.0-0:arm64 1.22.0-3+toradex1              arm64        GStreamer libraries from the "base" set
ii  libgstreamer1.0-0:arm64              1.22.0-2                       arm64        Core GStreamer libraries and elements 
```
but when it navigates to [https://www.onlinemictest.com/sound-test/](https://www.onlinemictest.com/sound-test/) the rendwer process crashes with the following logs
```bash
docker-compose-kiosk-1   | Could not determine the accessibility bus address
docker-compose-kiosk-1   |
docker-compose-kiosk-1   | (cog:1): GLib-GIO-WARNING **: 08:44:15.250: Your application does not implement g_application_activate() and has no handlers connected to the 'activate' signal.  It should do one of these.
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:15.615: <https://www.onlinemictest.com/sound-test/> Load started.
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:21.139: <https://www.onlinemictest.com/sound-test/> Loading...
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:24.522: <https://www.onlinemictest.com/sound-test/> Loaded successfully.
docker-compose-kiosk-1   | GStreamer element appsink not found. Please install it
docker-compose-kiosk-1   | GStreamer element autoaudiosink not found. Please install it
docker-compose-kiosk-1   |
docker-compose-kiosk-1   | (WPEWebProcess:16): GLib-GObject-WARNING **: 08:44:25.436: invalid (NULL) pointer instance
docker-compose-kiosk-1   |
docker-compose-kiosk-1   | (WPEWebProcess:16): GLib-GObject-CRITICAL **: 08:44:25.437: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
docker-compose-kiosk-1   |
docker-compose-kiosk-1   | (cog:1): Cog-Core-WARNING **: 08:44:25.483: <https://www.onlinemictest.com/sound-test/> Crash!: The renderer process crashed. Reloading the page may fix intermittent failures.
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:25.725: <https://www.onlinemictest.com/sound-test/> Load started.
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:25.731: <https://www.onlinemictest.com/sound-test/> Loading...
docker-compose-kiosk-1   | Cog-Core-Message: 08:44:25.745: <https://www.onlinemictest.com/sound-test/> Loaded successfully.
```

The `cog-media` container should be able to navigate successfully to [https://www.onlinemictest.com/sound-test/](https://www.onlinemictest.com/sound-test/) and play the sound.

See #17 

I installed a lot of packs, not sure if all of them are necessary.
On my local development environment this container is able to navigate to [https://www.onlinemictest.com/sound-test/](https://www.onlinemictest.com/sound-test/) without crashing the renderer.
But I can't try the sound since neither the touch screen, nor the mopuse works (differenmt issue IMHO).

Feel free to review this PR.